### PR TITLE
Update dragonmantank/cron-expression to v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "flarum/core": "^0.1.0-beta.15",
         "illuminate/console": "^6.20.0",
         "illuminate/support": "^6.20.0",
-        "dragonmantank/cron-expression": "^1.2.1",
+        "dragonmantank/cron-expression": "^3.1.0",
         "symfony/process": "~4.0"
     },
     "autoload": {


### PR DESCRIPTION
Update dragonmantank/cron-expression to v3, introducing PHP 8 compatibility

https://github.com/dragonmantank/cron-expression/blob/master/CHANGELOG.md#310---2020-11-24